### PR TITLE
Update dicomparser.py

### DIFF
--- a/dicompylercore/dicomparser.py
+++ b/dicompylercore/dicomparser.py
@@ -793,10 +793,10 @@ class DicomParser:
                         self.plan['rxdose'] = item.TargetPrescriptionDose * 100
         if (("FractionGroupSequence" in self.ds) and (self.plan['rxdose'] == 0)):
             fg = self.ds.FractionGroupSequence[0]
-            if ("ReferencedBeams" in fg) and \
-               ("NumberofFractionsPlanned" in fg):
-                beams = fg.ReferencedBeams
-                fx = fg.NumberofFractionsPlanned
+            if ("ReferencedBeamSequence" in fg) and \
+               ("NumberOfFractionsPlanned" in fg):
+                beams = fg.ReferencedBeamSequence
+                fx = fg.NumberOfFractionsPlanned
                 for beam in beams:
                     if "BeamDose" in beam:
                         self.plan['rxdose'] += beam.BeamDose * fx * 100

--- a/tests/test_dicomparser.py
+++ b/tests/test_dicomparser.py
@@ -234,7 +234,15 @@ class TestRTPlan(unittest.TestCase):
             'rxdose': 1400,
             'brachy': False,
         }
+
+        # Test DoseRefererenceSequence
         plandata = self.dp.GetPlan()
+        self.assertEqual(plandata, data)
+
+        # Test FractionGroupSequence
+        del self.dp.ds.DoseReferenceSequence
+        plandata = self.dp.GetPlan()
+        data['name'] = ''
         self.assertEqual(plandata, data)
 
     def test_plan_beams_in_fraction(self):


### PR DESCRIPTION
Solved bug: corrected wrong object names ReferencedBeams and NumberofFractionsPlanned changed to:  ReferencedBeamSequence and NumberOfFractionsPlanned in def GetPlan()