### PR TITLE
differential calculation modified

### DIFF
--- a/dicompylercore/dvh.py
+++ b/dicompylercore/dvh.py
@@ -154,7 +154,7 @@ class DVH(object):
         else:
             return DVH(**dict(
                 self.__dict__,
-                counts=np.append(abs(np.diff(self.counts) * -1), [0]),
+                counts=abs(np.diff(np.append(self.counts, 0))),
                 dvh_type=dvh_type))
 
     @property

--- a/tests/test_dicomparser.py
+++ b/tests/test_dicomparser.py
@@ -278,10 +278,10 @@ class TestRTDose(unittest.TestCase):
         self.assertEqual(dvh.dvh_type, 'cumulative')
         self.assertEqual(dvh.dose_units, 'Gy')
         self.assertEqual(dvh.volume_units, 'cm3')
-        self.assertEqual(dvh.volume, 437.46231750264502)
-        self.assertEqual(dvh.relative_dose().max, 22.142857142856986)
+        self.assertEqual(dvh.volume, 437.4623175026471)
+        self.assertEqual(dvh.relative_dose().max, 22.214285714285555)
         self.assertEqual(dvh.relative_dose().min, 0.14285714285714285)
-        self.assertEqual(dvh.relative_dose().mean, 4.5909162803374084)
+        self.assertEqual(dvh.relative_dose().mean, 4.590916280337491)
 
     def test_dose_grid(self):
         """Test if the dose grid can be parsed."""

--- a/tests/test_dvh.py
+++ b/tests/test_dvh.py
@@ -40,7 +40,7 @@ class TestDVH(unittest.TestCase):
         self.assertEqual(dvh.DVH.from_data(1, 1), dvh.DVH([1], [1]))
         self.assertEqual(
             repr(dvh.DVH.from_data(1, 1)),
-            "DVH(cumulative, 1 bins: [0:1] Gy, volume: 0 cm3, "
+            "DVH(cumulative, 1 bins: [0:1] Gy, volume: 1 cm3, "
             "name: None, rx_dose: 0 Gy)")
         assert_array_equal(dvh.DVH.from_data(0, 1).bins, array([0, 0]))
         assert_array_equal(dvh.DVH.from_data(5, 2).bins, array([0, 2, 4, 5]))
@@ -122,10 +122,10 @@ class TestDVH(unittest.TestCase):
 
     def test_dvh_properties(self):
         """Test if the DVH properties can be derived."""
-        self.assertEqual(self.dvh.max, 14.569999999999734)
+        self.assertEqual(self.dvh.max, 14.579999999999734)
         self.assertEqual(self.dvh.min, 14.069999999999744)
-        self.assertEqual(self.dvh.mean, 14.285830178442305)
-        self.assertEqual(self.dvh.volume, 12.809180549338702)
+        self.assertEqual(self.dvh.mean, 14.285830178442307)
+        self.assertEqual(self.dvh.volume, 12.809180549338803)
 
     def test_dvh_value(self):
         """Test if the DVHValue class works as expected."""

--- a/tests/test_dvhcalc.py
+++ b/tests/test_dvhcalc.py
@@ -86,17 +86,17 @@ class TestDVHCalc(unittest.TestCase):
         dvh = self.calc_dvh(5)
 
         # Volume
-        self.assertAlmostEqual(dvh.volume, 440.212499999)
+        self.assertAlmostEqual(dvh.volume, 440.23124999)
         # Min dose bin
         self.assertAlmostEqual(dvh.bins[0], 0)
         # Max dose bin
-        self.assertEqual(dvh.bins[-1], 3.100000000)
+        self.assertEqual(dvh.bins[-1], 3.1)
         # Max dose to structure
-        self.assertAlmostEqual(dvh.max, 3.089999999)
+        self.assertAlmostEqual(dvh.max, 3.1)
         # Min dose to structure
-        self.assertAlmostEqual(dvh.min, 0.02999999)
+        self.assertAlmostEqual(dvh.min, 0.03)
         # Mean dose to structure
-        self.assertAlmostEqual(dvh.mean, 0.647428656)
+        self.assertAlmostEqual(dvh.mean, 0.6475329)
 
     def test_dvh_calculation_with_dose_limit(self):
         """Test if a DVH can be calculated with a max dose limit."""
@@ -104,22 +104,22 @@ class TestDVHCalc(unittest.TestCase):
         limitdvh = self.calc_dvh(5, limit=500)
 
         # Volume
-        self.assertAlmostEqual(limitdvh.volume, 440.212499999)
+        self.assertAlmostEqual(limitdvh.volume, 440.23124999)
         # Min dose bin
         self.assertAlmostEqual(limitdvh.bins[0], 0)
         # Max dose bin
-        self.assertEqual(limitdvh.bins[-1], 3.100000000)
+        self.assertEqual(limitdvh.bins[-1], 3.1)
         # Max dose to structure
-        self.assertAlmostEqual(limitdvh.max, 3.089999999)
+        self.assertAlmostEqual(limitdvh.max, 3.1)
         # Min dose to structure
-        self.assertAlmostEqual(limitdvh.min, 0.02999999)
+        self.assertAlmostEqual(limitdvh.min, 0.03)
         # Mean dose to structure
-        self.assertAlmostEqual(limitdvh.mean, 0.647428656)
+        self.assertAlmostEqual(limitdvh.mean, 0.6475329)
 
         # Set the dose limit to 2000 cGy (higher than max dose)
         highlimitdvh = self.calc_dvh(5, limit=2000)
         # Max dose bin
-        self.assertEqual(highlimitdvh.bins[-1], 3.100000000)
+        self.assertEqual(highlimitdvh.bins[-1], 3.1)
 
         # Set the dose limit to 1 cGy (should produce an empty histogram)
         lowlimitdvh = self.calc_dvh(5, limit=1)
@@ -133,10 +133,10 @@ class TestDVHCalc(unittest.TestCase):
 
         # Full structure volume (calculated inside/outside dose grid)
         include_vol_dvh = self.calc_dvh(8, calculate_full_volume=True)
-        self.assertAlmostEqual(include_vol_dvh.volume, 0.54086538)
+        self.assertAlmostEqual(include_vol_dvh.volume, 0.56249999)
         # Partial volume (calculated only within dose grid)
         partial_vol_dvh = self.calc_dvh(8, calculate_full_volume=False)
-        self.assertAlmostEqual(partial_vol_dvh.volume, 0.46874999)
+        self.assertAlmostEqual(partial_vol_dvh.volume, 0.48749999)
 
     @unittest.skipUnless(skimage_available, "scikit-image not installed")
     def test_dvh_with_in_plane_interpolation(self):
@@ -146,17 +146,17 @@ class TestDVHCalc(unittest.TestCase):
             interpolation_resolution=(2.5 / 8))
 
         # Volume
-        self.assertAlmostEqual(interp_dvh.volume, 0.51560486)
+        self.assertAlmostEqual(interp_dvh.volume, 0.51590551)
         # Min dose bin
         self.assertAlmostEqual(interp_dvh.bins[0], 0)
         # Max dose bin
         self.assertEqual(interp_dvh.bins[-1], 12.98)
         # Max dose to structure
-        self.assertAlmostEqual(interp_dvh.max, 12.95)
+        self.assertAlmostEqual(interp_dvh.max, 12.98)
         # Min dose to structure
         self.assertAlmostEqual(interp_dvh.min, 1.32)
         # Mean dose to structure
-        self.assertAlmostEqual(interp_dvh.mean, 7.69203790)
+        self.assertAlmostEqual(interp_dvh.mean, 7.695116550116536)
 
     def test_dvh_with_structure_extents(self):
         """Test if DVH calculation is same as normal with structure extents."""
@@ -170,7 +170,7 @@ class TestDVHCalc(unittest.TestCase):
         self.create_new_contour(3, [-230.0, -520.0, 260.0, 0.0], 24.56)
 
         structure_extents_dvh = self.calc_dvh(3, use_structure_extents=True)
-        self.assertAlmostEqual(structure_extents_dvh.volume, 464.38125)
+        self.assertAlmostEqual(structure_extents_dvh.volume, 464.40000)
 
     def test_dvh_with_in_plane_interpolation_sampling_fail(self):
         """Test if DVH calculation fails when the sampling rate is invalid."""
@@ -184,17 +184,17 @@ class TestDVHCalc(unittest.TestCase):
         dvh = self.calc_dvh(8, interpolation_segments=2)
 
         # Volume
-        self.assertAlmostEqual(dvh.volume, 0.4687499999)
+        self.assertAlmostEqual(dvh.volume, 0.47499999)
         # Min dose bin
         self.assertAlmostEqual(dvh.bins[0], 0)
         # Max dose bin
         self.assertEqual(dvh.bins[-1], 10.0)
         # Max dose to structure
-        self.assertAlmostEqual(dvh.max, 9.98)
+        self.assertAlmostEqual(dvh.max, 10.0)
         # Min dose to structure
         self.assertAlmostEqual(dvh.min, 2.03)
         # Mean dose to structure
-        self.assertAlmostEqual(dvh.mean, 6.4298000000)
+        self.assertAlmostEqual(dvh.mean, 6.4767105)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hi Bastula,
`0` should be first appended at the end of the cumulative DVH and `np.diff` can then be used to differentiate the DVH. 
In this way the information in last bin of the cumulative DVH can be preserved, comparing to append a `0` after the `diff` manipulation. 

I have not understood the `* -1`. Would you explain a little bit?

And The modification would indeed fail related unittest (as you can see from the logfiles), But I believe this reasoning is correct. 

Thank you for your time,

[unittest.log](https://github.com/dicompyler/dicompyler-core/files/2289844/unittest.log)

