### PR TITLE
Fix/d100 is 0 gy

### DIFF
--- a/dicompylercore/dvh.py
+++ b/dicompylercore/dvh.py
@@ -461,8 +461,23 @@ class DVH(object):
             volume_counts = self.relative_volume.counts
         else:
             volume_counts = self.absolute_volume(self.volume).counts
+
         if volume > volume_counts.max():
             return DVHValue(0.0, self.dose_units)
+
+        # D100 case
+        if volume == 100 and not volume_units:
+            # Flipping the difference volume array
+            reversed_difference_of_volume = np.flip(
+                    np.fabs(volume_counts - volume), 0)
+
+            # Index of the first minimum value in reversed array
+            index_min_value = np.argmin(reversed_difference_of_volume)
+            index_range = len(reversed_difference_of_volume) - 1
+
+            return DVHValue(
+                self.bins[index_range - index_min_value], self.dose_units)
+
         # TODO Add interpolation
         return DVHValue(
             self.bins[np.argmin(

--- a/tests/test_dvh.py
+++ b/tests/test_dvh.py
@@ -154,6 +154,9 @@ class TestDVH(unittest.TestCase):
             self.dvh.volume_constraint(100, 'Gy'),
             dvh.DVHValue(0.0, 'cm3'))
         self.assertEqual(
+            self.dvh.dose_constraint(100),
+            dvh.DVHValue(14.059999999999745, 'Gy'))
+        self.assertEqual(
             self.dvh.dose_constraint(90),
             dvh.DVHValue(14.169999999999742, 'Gy'))
         self.assertEqual(


### PR DESCRIPTION
dose_constraint(100) now give the expected value, and not 0 Gy. I also added a test that assure this.

The method always returned 0 because of that:

`np.argmin` note:
> In case of multiple occurrences of the minimum values, the indices corresponding to the first occurrence are returned.
 
SOLUTION:
flip the array and apply np.argmin to get the minimum value index of the reversed array.
After, substract the biggest possible index of the array by the minimum value index to get the real index where the D100 value is. 

related to #25 