### PR TITLE
fix: Window calculation if not present in header

### DIFF
--- a/dicompylercore/dicomparser.py
+++ b/dicompylercore/dicomparser.py
@@ -410,7 +410,7 @@ class DicomParser:
             if (pixel_array.min() < wmin):
                 wmin = pixel_array.min()
             # Default window is the range of the data array
-            window = int(abs(wmax) + abs(wmin))
+            window = int(wmax - wmin)
             # Default level is the range midpoint minus the window minimum
             level = int(window / 2 - abs(wmin))
         return window, level


### PR DESCRIPTION
Window should be calculated as max - min. This only applies for the case if the window / level was not present in the original DICOM header. Closes #99.