### PR TITLE
fix: Preserve global maximum dose

### DIFF
--- a/dicompylercore/dvhcalc.py
+++ b/dicompylercore/dvhcalc.py
@@ -155,7 +155,7 @@ def calculate_dvh(structure,
         x, y = x.flatten(), y.flatten()
         dosegridpoints = np.vstack((x, y)).T
 
-        maxdose = int(dd['dosemax'] * dd['dosegridscaling'] * 100)
+        maxdose = int(dd['dosemax'] * dd['dosegridscaling'] * 100) + 1
         # Remove values above the limit (cGy) if specified
         if isinstance(limit, int):
             if (limit < maxdose):


### PR DESCRIPTION
When calculating DVH for external structure or PTVs, global maximum dose is now underestimated.

Now DVH is calculated between `0` to `maxdose` in L158 of `dvhcalc.py` .
A maximum dose point will be **ignored** when calculating histogram in L274-L276 of 'dvhcalc.py' because casting float to int with `int()` truncates the decimal point as you know.

https://github.com/dicompyler/dicompyler-core/blob/81d8aaa75e286aa7938fa0759756062a846c544e/dicompylercore/dvhcalc.py#L158

https://github.com/dicompyler/dicompyler-core/blob/81d8aaa75e286aa7938fa0759756062a846c544e/dicompylercore/dvhcalc.py#L274-L276

The maximum dose of BODY of test data has changed from 14.67 to 14.69 Gy when adding one to `maxdose` where the true maximum dose is 14.681 Gy in DICOM RT DOSE file.  