### PR TITLE
Remove relative boundary dose checks

### DIFF
--- a/dicompylercore/dose.py
+++ b/dicompylercore/dose.py
@@ -161,7 +161,11 @@ class DoseGrid:
 
     @property
     def max_boundary_relative_dose(self):
-        return self.max_boundary_dose / np.max(self.dose_grid)
+        grid_max = np.max(self.dose_grid)
+        if grid_max:
+            return self.max_boundary_dose / grid_max
+        else:
+            return 0
 
     ####################################################
     # Tools

--- a/dicompylercore/dose.py
+++ b/dicompylercore/dose.py
@@ -95,25 +95,11 @@ class DoseGrid:
             # x and z are swapped in the pixel_array
             pixel_array = self.ds.pixel_array * self.ds.DoseGridScaling
             self.dose_grid = np.swapaxes(pixel_array, 0, 2)
-
-            self._validate_boundary_dose(boundary_dose_threshold)
         else:
             raise AttributeError(
                 "The DoseGrid class requires an RTDOSE file or dataset. "
                 "%s was detected" % self.ds.Modality
             )
-
-    def _validate_boundary_dose(self, threshold):
-        """Raise a warning if any dose on the boundary of the dose grid
-        (normalized to its global max dose) is greater than threshold"""
-        if self.max_boundary_relative_dose > threshold:
-            msg = (
-                "A boundary dose greater than %s%% of the maximum dose "
-                "was detected." % (threshold * 100)
-            )
-            warn(msg)
-            return False
-        return True
 
     ####################################################
     # Basic properties
@@ -135,7 +121,8 @@ class DoseGrid:
     @property
     def scale(self):
         """Get the dose grid resolution (xyz)"""
-        if np.any(np.diff(np.diff(self.ds.GridFrameOffsetVector))):
+        diffs = np.diff(self.ds.GridFrameOffsetVector)
+        if not np.all(np.isclose(diffs, [diffs[0]]*len(diffs))):
             raise NotImplementedError(
                 "Non-uniform GridFrameOffsetVector detected. Interpolated "
                 "summation of non-uniform dose-grid scales is not supported."
@@ -161,11 +148,7 @@ class DoseGrid:
 
     @property
     def max_boundary_relative_dose(self):
-        grid_max = np.max(self.dose_grid)
-        if grid_max:
-            return self.max_boundary_dose / grid_max
-        else:
-            return 0
+        return self.max_boundary_dose / np.max(self.dose_grid)
 
     ####################################################
     # Tools

--- a/tests/test_dose.py
+++ b/tests/test_dose.py
@@ -269,20 +269,6 @@ class TestDose(unittest.TestCase):
             self.dosegrid.max_boundary_relative_dose, 0.009437111038635319
         )
 
-        warnings.filterwarnings("ignore")
-        self.assertFalse(self.dosegrid._validate_boundary_dose(0.001))
-        warnings.filterwarnings("default")
-
-        self.assertTrue(self.dosegrid._validate_boundary_dose(0.01))
-
-    def test_zero_grid_relative_dose(self):
-        # Change pixel data to zeros
-        ds = self.rtdose.ds
-        pix = ds.pixel_array
-        ds.PixelData = zeros(pix.shape).tobytes()
-        grid = dose.DoseGrid(ds)
-        self.assertTrue(grid.max_boundary_relative_dose == 0)
-
     def test_non_uniform_dose_grid_scale(self):
         """Check that a non-uniform dose grid is detected"""
         ds = dose.DoseGrid(self.rtdose_dcm).ds

--- a/tests/test_dose.py
+++ b/tests/test_dose.py
@@ -275,6 +275,14 @@ class TestDose(unittest.TestCase):
 
         self.assertTrue(self.dosegrid._validate_boundary_dose(0.01))
 
+    def test_zero_grid_relative_dose(self):
+        # Change pixel data to zeros
+        ds = self.rtdose.ds
+        pix = ds.pixel_array
+        ds.PixelData = zeros(pix.shape).tobytes()
+        grid = dose.DoseGrid(ds)
+        self.assertTrue(grid.max_boundary_relative_dose == 0)
+
     def test_non_uniform_dose_grid_scale(self):
         """Check that a non-uniform dose grid is detected"""
         ds = dose.DoseGrid(self.rtdose_dcm).ds


### PR DESCRIPTION
I have a use case where it is convenient to create a zero-based dose grid to control the interpolation matrix before adding others.

But if a dose grid is all zeros, the current max relative calculation fails, and this is also done on `DoseGrid` instance initialization.

This PR adds a simple check to avoid a divide-by-zero situation.  Test included.
