### PR TITLE
Update docs to show class init docstring

### DIFF
--- a/dicompylercore/dose.py
+++ b/dicompylercore/dose.py
@@ -47,16 +47,18 @@ class DoseGrid:
             The order has to be in the range 0-5.
             0: the nearest grid point, 1: trilinear, 2 to 5: spline
             See scipy.ndimage.map_coordinates documentation for more details
-        mode : {‘constant’, ‘nearest’}, optional
+        mode : 'constant' or 'nearest', optional
             The mode parameter determines how the other dose grid is extended
-            beyond its boundaries. Default is ‘constant’. Behavior for
+            beyond its boundaries. Default is ``'constant'``. Behavior for
             these values is as follows:
-            ‘constant’ (k k k k | a b c d | k k k k)
+
+            ``'constant'`` (k k k k | a b c d | k k k k)
                 The other dose grid is extended by filling all values beyond
                 the edge with the same constant value, defined by the cval
                 parameter.
-            ‘nearest’ (a a a a | a b c d | d d d d)
+            ``'nearest'`` (a a a a | a b c d | d d d d)
                 The input is extended by replicating the last pixel.
+
             Additional modes are available, see scipy.ndimage.map_coordinates
             documentation for more details.
         cval : scalar, optional

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -278,3 +278,6 @@ texinfo_documents = [
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
+
+# Set autoclass_content to show both class and init docstring
+autoclass_content = "both"


### PR DESCRIPTION
Per @cutright, the `__init__` method docstring was not showing up in the docs. Following the sphinx [docs](https://www.sphinx-doc.org/en/1.8/usage/extensions/autodoc.html#confval-autoclass_content), the default setting can be changed to show the `__init__` method as part of the main class docs.