### PR TITLE
Dose interpolation fix due to indexing issue

### DIFF
--- a/dicompylercore/dvhcalc.py
+++ b/dicompylercore/dvhcalc.py
@@ -162,8 +162,8 @@ def _calculate_dvh(structure,
             # Determine LUT from extents
             if use_structure_extents:
                 dd['lut'] = \
-                    (dd['lut'][0][dgindexextents[0]:dgindexextents[2]],
-                     dd['lut'][1][dgindexextents[1]:dgindexextents[3]])
+                    (dd['lut'][0][dgindexextents[0]:dgindexextents[2]+1],
+                     dd['lut'][1][dgindexextents[1]:dgindexextents[3]+1])
             # If interpolation is enabled, generate new LUT from extents
             if interpolation_resolution:
                 dd['lut'] = get_resampled_lut(
@@ -455,7 +455,7 @@ def get_resampled_lut(index_extents,
             % min_pixel_spacing[1] +
             " where n is an integer. Value provided was %s."
             % new_pixel_spacing[1])
-    sampling_rate = np.array([
+    sampling_rate = 1 + np.array([
         abs(index_extents[0] - index_extents[2]),
         abs(index_extents[1] - index_extents[3])
     ])
@@ -488,8 +488,8 @@ def get_interpolated_dose(dose, z, resolution, extents):
     """
     # Return the dose bounded by extents if interpolation is not required
     d = dose.GetDoseGrid(z)
-    extent_dose = d[extents[1]:extents[3],
-                    extents[0]:extents[2]] if len(extents) else d
+    extent_dose = d[extents[1]:extents[3]+1,
+                    extents[0]:extents[2]+1] if len(extents) else d
     if not resolution:
         return extent_dose
     if not skimage_available:


### PR DESCRIPTION
I noticed a shift in the interpolated DVH calculations, even if the resolution was equal to the original dose grid.  Upon inspection of the code, it appears as if variables there were a couple list indexing issues.

The light blue line is calculated with the current `dicompyler-core` master.  The orange is calculated with Eclipse, and imported as a DICOM DVH.  The dark blue line is calculated with this pull request.

The edits to lines 165 and 166 were applied intuitively, but I have not done any testing other than to show it doesn't crash.

The `+1`'s to `sampling_rate` and `extent_dose` alone fix the shifted DVH.

<img width="924" alt="image" src="https://user-images.githubusercontent.com/4778878/101996457-2fd33b00-3c98-11eb-87f7-971e13e1faa6.png">
