### PR TITLE
Move to Python 3.9 to build docs on Read The Docs.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,10 @@
+version: 2
+
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "3.9"
+formats: all
+python:
+   install:
+   - requirements: requirements_dev.txt


### PR DESCRIPTION
Move to Python 3.9 to build docs on Read The Docs.