### PR TITLE
Fix: Validate Z-Coordinate Uniformity in DICOM Contour Processing

### DIFF
--- a/dicompylercore/dicomparser.py
+++ b/dicompylercore/dicomparser.py
@@ -590,6 +590,19 @@ class DicomParser:
                     structures[number]['empty'] = True
 
         return structures
+    
+    def verify_z_coordinates(self, contour_points):
+        """
+        Verify if all z-coordinates in the contour points are identical.
+
+        Parameters:
+        - contour_points (list of list of float): List of contour points (each is an xyz triplet).
+
+        Returns:
+        - bool: True if all z-coordinates are identical, False otherwise.
+        """
+        z_coordinates = [point[2] for point in contour_points]
+        return all(z == z_coordinates[0] for z in z_coordinates)
 
     def GetStructureCoordinates(self, roi_number):
         """Get the list of coordinates for each plane of the structure.
@@ -624,6 +637,11 @@ class DicomParser:
                             # for easier parsing
                             plane['data'] = \
                                 self.GetContourPoints(c.ContourData)
+                            
+                            # Verify if all z-coordinates in this plane are identical
+                            if not self.verify_z_coordinates(plane['data']):
+                                print(f"Warning ROI Number {roi_number}: Not all z-coordinates are identical. Execution halted.")
+                                return {}  
 
                             # Add each plane to the planes dict
                             # of the current ROI


### PR DESCRIPTION
This PR is related to #377 

Changes:

- Added verify_z_coordinates to check z-coordinate uniformity in plane['data'] for each DICOM contour.
- Integrated check before adding planes to the planes dict. If non-uniform z-coordinates are found, it halts processing and logs a warning.

Reason:
Ensures DVH integrity by verifying z-coordinate uniformity within contours