### PR TITLE
Update to work with pydicom 2.4+, 3.X, Python 3.10+ (#6)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,19 +13,22 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python-version: ["3.7", "3.8", "3.9", "3.10"]
-
+                python-version: ["3.10", "3.11", "3.12", "3.13"]
+                pydicom-version: ["pydicom-latest"]
+                include:
+                  - python-version: "3.10"
+                    pydicom-version: "pydicom~=2.4.4"
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v5
               with:
                   python-version: ${{ matrix.python-version }}
 
             - name: Cache Python dependencies
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               with:
                   path: ~/.cache/pip
                   key: ${{ hashFiles('setup.py') }}
@@ -37,6 +40,11 @@ jobs:
                   pip install coverage
                   pip install coveralls
                   pip install codecov
+            
+            - name: Force pydicom version if needed
+              if: startsWith(matrix.pydicom-version, '2')
+              run: |
+                  pip install -U "${{ matrix.pydicom-version }}"
 
             - name: Run tests via coverage
               run: |

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       # Checkout the repository to the GitHub Actions runner
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Execute Codacy Analysis CLI and generate a SARIF output with the security issues identified during the analysis
       - name: Run Codacy Analysis CLI

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,6 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v3
+        uses: actions/dependency-review-action@v4

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 0.5.7 (unreleased)
 ------------------
 - Dropped support for Python 2.
+- pydicom 3.X supported (requirement now >= pydicom 2.4.0)
 
 0.5.6 (2023-05-08)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ Dependencies
 ------------
 
 -  `numpy <http://www.numpy.org>`__ 1.2 or higher
--  `pydicom <https://pydicom.github.io>`__ 0.9.9 or higher (pydicom 1.0 compatible)
+-  `pydicom <https://pydicom.github.io>`__ 2.4.0 or higher
 -  `matplotlib <http://matplotlib.org>`__ 1.3.0 or higher (for DVH calculation)
 -  Optional:
 

--- a/dicompylercore/dvh.py
+++ b/dicompylercore/dvh.py
@@ -108,16 +108,14 @@ class DVH(object):
 
     def __repr__(self):
         """String representation of the class."""
-        return 'DVH(%s, %r bins: [%r:%r] %s, volume: %r %s, name: %r, ' \
-            'rx_dose: %d %s%s)' % \
-            (self.dvh_type, self.counts.size, self.bins.min(),
-                self.bins.max(), self.dose_units,
-                self.volume, self.volume_units,
-                self.name,
-                0 if not self.rx_dose else self.rx_dose,
-                self.dose_units,
-                ', *Notes: ' + self.notes if self.notes else '')
-
+        return (
+            f'DVH({self.dvh_type}, {self.counts.size} bins: '
+            f'[{self.bins.min()}:{self.bins.max()}] {self.dose_units}, '
+            f'volume: {self.volume} {self.volume_units}, name: {self.name}, '
+            f'rx_dose: {0 if not self.rx_dose else self.rx_dose} '
+            f'{self.dose_units}'
+            f'{", *Notes: " + self.notes if self.notes else ""})'
+        )
     def __eq__(self, other):
         """Comparison method between two DVH objects.
 

--- a/dicompylercore/util.py
+++ b/dicompylercore/util.py
@@ -132,7 +132,7 @@ def piecewise(x, condlist, funclist, *args, **kw):
     y = np.zeros(x.shape, x.dtype)
     for k in range(n):
         item = funclist[k]
-        if not isinstance(item, collections.Callable):
+        if not isinstance(item, collections.abc.Callable):
             y[condlist[k]] = item
         else:
             vals = x[condlist[k]]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,7 +44,7 @@ extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode',
               'sphinx.ext.napoleon']
 
 autodoc_mock_imports = [
-    'numpy', 'dicom', 'pydicom', 'pydicom', 'dicom',
+    'numpy', 'dicom', 'pydicom',
     'PIL', 'numpy.core', 'matplotlib', 'skimage', 'scipy']
 autodoc_member_order = 'bysource'
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "numpy>=1.2",
-        "pydicom>=0.9.9",
+        "pydicom>=2.4.0,<4",
         "matplotlib>=1.3.0"
     ],
     extras_require={
@@ -56,11 +56,10 @@ setup(
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Topic :: Scientific/Engineering :: Medical Science Apps.',
         'Topic :: Scientific/Engineering :: Physics'
     ],

--- a/tests/test_dicomparser.py
+++ b/tests/test_dicomparser.py
@@ -7,16 +7,12 @@
 
 import unittest
 import os
-from dicompylercore import dicomparser
-from dicompylercore.config import pil_available, shapely_available
-try:
-    from pydicom.multival import MultiValue as mv
-    from pydicom.valuerep import DSfloat
-except ImportError:
-    from dicom.multival import MultiValue as mv
-    from dicom.valuerep import DSfloat
+from pydicom.multival import MultiValue as mv
+from pydicom.valuerep import DSfloat
 from numpy import array, arange
 from numpy.testing import assert_array_equal, assert_array_almost_equal
+from dicompylercore import dicomparser
+from dicompylercore.config import pil_available, shapely_available
 
 basedata_dir = "tests/testdata"
 example_data = os.path.join(basedata_dir, "example_data")

--- a/tests/test_dose.py
+++ b/tests/test_dose.py
@@ -8,16 +8,8 @@
 
 import unittest
 import os
-from dicompylercore import dicomparser, dose
 
-try:
-    from pydicom.dataset import Dataset
-    from pydicom.sequence import Sequence
-    from pydicom import read_file as read_dicom
-except ImportError:
-    from dicom.dataset import Dataset
-    from dicom.sequence import Sequence
-    from dicom import read_file as read_dicom
+from pydicom import dcmread as read_dicom
 from numpy import arange, zeros
 from numpy.testing import (
     assert_array_almost_equal,
@@ -26,6 +18,7 @@ from numpy.testing import (
 )
 import warnings
 from dicompylercore.config import mpl_available, scipy_available
+from dicompylercore import dicomparser, dose
 
 basedata_dir = "tests/testdata"
 example_data = os.path.join(basedata_dir, "example_data")

--- a/tests/test_dvhcalc.py
+++ b/tests/test_dvhcalc.py
@@ -6,19 +6,15 @@
 
 import unittest
 import os
+from pydicom.dataset import Dataset
+from pydicom.sequence import Sequence
+from numpy import arange
+from numpy.testing import assert_allclose
+from .util import fake_rtdose, fake_ss
 from dicompylercore import dicomparser, dvhcalc
 from dicompylercore.config import skimage_available
 from dicompylercore.dvh import DVH
 from dicompylercore.dvhcalc import get_dvh
-try:
-    from pydicom.dataset import Dataset
-    from pydicom.sequence import Sequence
-except ImportError:
-    from dicom.dataset import Dataset
-    from dicom.sequence import Sequence
-from numpy import arange
-from numpy.testing import assert_allclose
-from .util import fake_rtdose, fake_ss
 
 
 basedata_dir = "tests/testdata"


### PR DESCRIPTION
* Update pydicom supported to >=2.4..0.  Closes #381 
* Update to Python 3.10+ only, adjust setup.py and tests
* fix DVH repr problems with 'np.int(...)' repr
* collections.Callable -> collections.abc.Callable
* Resolve fixing of file_meta info
* Update workflows for testing pydicom 2.4, 3.X
* update some of the GitHub actions script versions